### PR TITLE
Fix judge workflow

### DIFF
--- a/.github/workflows/judge.yml
+++ b/.github/workflows/judge.yml
@@ -1,0 +1,55 @@
+name: Judge PRs
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  issue_comment:
+    types: [created]
+
+jobs:
+  judge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+
+            async function listOpenPRs() {
+              const { data } = await github.rest.pulls.list({ owner, repo, state: 'open' });
+              return data;
+            }
+
+            const commentTrigger =
+              github.event_name === 'issue_comment' &&
+              github.event.comment.body.trim() === '/judge' &&
+              !!github.event.issue.pull_request;
+            const openPRs = await listOpenPRs();
+            const autoTrigger = github.event_name === 'pull_request' && openPRs.length >= 3;
+
+            if (!commentTrigger && !autoTrigger) {
+              core.info('Judging conditions not met.');
+              return;
+            }
+
+            async function scorePR(pr) {
+              const { data: files } = await github.rest.pulls.listFiles({ owner, repo, pull_number: pr.number });
+              const stats = files.reduce((acc, f) => { return { additions: acc.additions + f.additions, deletions: acc.deletions + f.deletions }; }, { additions: 0, deletions: 0 });
+              return stats.additions + stats.deletions; // lower is better
+            }
+
+            const scored = [];
+            for (const pr of openPRs) {
+              const score = await scorePR(pr);
+              scored.push({ pr, score });
+            }
+            if (scored.length === 0) {
+              core.info('No open PRs.');
+              return;
+            }
+
+            scored.sort((a, b) => a.score - b.score);
+            const winner = scored[0].pr;
+            await github.rest.pulls.merge({ owner, repo, pull_number: winner.number, merge_method: 'squash' });
+            await github.rest.issues.createComment({ owner, repo, issue_number: winner.number, body: 'This PR was automatically judged as the best and merged.' });
+            core.info(`Merged PR #${winner.number}`);


### PR DESCRIPTION
## Summary
- fix GitHub Actions script to avoid duplicate `core` import
- ensure `/judge` comment only triggers on PRs
- log merge info when merging winning PR

## Testing
- `git status --short`
