### PR TITLE
Implement CLI main and uppercase option

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,12 +1,24 @@
 // Greets the provided name with a "Hello" message.
 // Defaults to "world" when no name is given.
-export function hello(name: string = 'world'): string {
-  return `Hello, ${name}!`;
+export function hello(
+  name: string = 'world',
+  options?: { upperCase?: boolean }
+): string {
+  let greeting = `Hello, ${name}!`;
+  if (options?.upperCase) {
+    greeting = greeting.toUpperCase();
+  }
+  return greeting;
+}
+
+export function main(args: string[]): void {
+  const [name, flag] = args;
+  const upperCase = flag === '--upper';
+  console.log(hello(name, { upperCase }));
 }
 
 // If this file is executed directly, greet the first command line argument or
 // use the default greeting.
 if (require.main === module) {
-  const [, , name] = process.argv;
-  console.log(hello(name));
+  main(process.argv.slice(2));
 }


### PR DESCRIPTION
## Summary
- extend `hello` to support optional upperCase flag
- add `main` CLI entry point

## Testing
- `tsc index.ts --target ES2019` *(fails: Cannot find name 'require')*