### PR TITLE
Implement new CLI in index.ts

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,12 +1,31 @@
 // Greets the provided name with a "Hello" message.
 // Defaults to "world" when no name is given.
+/**
+ * Returns a friendly greeting for the provided name.
+ *
+ * @param name - Name to greet. Defaults to 'world'.
+ */
 export function hello(name: string = 'world'): string {
   return `Hello, ${name}!`;
+}
+
+/**
+ * Returns a farewell message for the provided name.
+ *
+ * @param name - Name to bid farewell. Defaults to 'world'.
+ */
+export function goodbye(name: string = 'world'): string {
+  return `Goodbye, ${name}!`;
 }
 
 // If this file is executed directly, greet the first command line argument or
 // use the default greeting.
 if (require.main === module) {
-  const [, , name] = process.argv;
-  console.log(hello(name));
+  const [, , cmd, name] = process.argv;
+  if (cmd === '--goodbye') {
+    console.log(goodbye(name));
+  } else {
+    // treat the first argument as name when no option is provided
+    console.log(hello(cmd));
+  }
 }


### PR DESCRIPTION
## Summary
- add a goodbye helper
- support `--goodbye` option when running index.ts directly

## Testing
- `npx tsc index.ts --target ES2019` *(fails: Cannot find name 'require')*
- `npx tsc index.ts --target ES2019 --lib ES2020` *(fails: Cannot find name 'require')*